### PR TITLE
update to 0.7.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "visions" %}
-{% set version = "0.7.1" %}
+{% set version = "0.7.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d9d10a0da8de80d0704c28c084282abbd3273065cd9e6a494b6fe7e3b339ee23
+  sha256: 4f66c1da369cdbced5e1e2d2c43104caa8cfb9c694006cea1592e1673cfc1153
 
 build:
   number: 0
@@ -25,7 +25,6 @@ requirements:
     - pandas >=0.25.3
     - python >=3.6
     - tangled-up-in-unicode >=0.0.4
-    - bottleneck
     - multimethod 1.4
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
 requirements:
   host:
     - pip
+    - setuptools
+    - wheel
     - python
   run:
     - attrs >=19.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,13 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
     - attrs >=19.3.0
     - networkx >=2.4
     - numpy
     - pandas >=0.25.3
-    - python >=3.6
+    - python
     - tangled-up-in-unicode >=0.0.4
     - multimethod 1.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:


### PR DESCRIPTION
* [x] upstream repo https://github.com/dylan-profiler/visions
* [x] run tests on dependent packages - pandas-profiling pinned to visions 0.5.0, no other dependent packages
* [x] go through [changelog] - couldn't find
* [x] diff https://github.com/dylan-profiler/visions/compare/v0.7.1...v0.7.4
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream
```
meta.yaml:
    - attrs >=19.3.0
    - networkx >=2.4
    - numpy
    - pandas >=0.25.3
    - python
    - tangled-up-in-unicode >=0.0.4
    - multimethod 1.4


requirements.txt:
numpy
pandas>=0.25.3
attrs>=19.3.0
networkx>=2.4
tangled_up_in_unicode>=0.0.4
multimethod>=1.4
```